### PR TITLE
Add 16KB page support on Android by upgrading Chromium and enabling platform flags

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -16,7 +16,7 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../src" "${CMAKE_CURRENT_BINARY_DI
 # versions of CMake.
 cmake_policy(VERSION 3.14...3.25)
 
-set(PDFIUM_RELEASE chromium%2F6406)
+set(PDFIUM_RELEASE chromium%2F7442)
 set(PDFIUM_DIR ${CMAKE_BINARY_DIR}/pdfium/${ANDROID_ABI})
 
 file(MAKE_DIRECTORY ${PDFIUM_DIR})

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-version := "6276"
+version := "7442"
 
 @configure: download-headers create-ast create-mapping create-binding
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,12 +6,21 @@ cmake_minimum_required(VERSION 3.10)
 project(flutter_pdfium_library VERSION 0.0.1 LANGUAGES C)
 
 add_library(flutter_pdfium SHARED
-  "flutter_pdfium.c"
+        "flutter_pdfium.c"
 )
 
 set_target_properties(flutter_pdfium PROPERTIES
-  PUBLIC_HEADER flutter_pdfium.h
-  OUTPUT_NAME "flutter_pdfium"
+        PUBLIC_HEADER flutter_pdfium.h
+        OUTPUT_NAME "flutter_pdfium"
 )
 
 target_compile_definitions(flutter_pdfium PUBLIC DART_SHARED_LIB)
+
+if (ANDROID)
+    if (COMMAND target_link_options)
+        target_link_options(flutter_pdfium PRIVATE "-Wl,-z,max-page-size=16384")
+    else ()
+        set(CMAKE_SHARED_LINKER_FLAGS
+                "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,max-page-size=16384")
+    endif ()
+endif ()


### PR DESCRIPTION
This PR updates Chromium and applies the required Android compile flags to support
devices using 16KB memory pages.

Older builds assume 4KB pages and may crash on newer ARM64 devices. Upgrading Chromium
and enabling these flags ensures PDFium runs correctly on both 4KB and 16KB page systems.

No functional changes beyond compatibility improvements.