### PR TITLE
Fix iOS build failure caused by mismatched PDFium version

### DIFF
--- a/ios/flutter_pdfium.podspec
+++ b/ios/flutter_pdfium.podspec
@@ -1,4 +1,4 @@
-version = '6276'
+version = '7442'
 
 Pod::Spec.new do |s|
   s.name             = 'flutter_pdfium'


### PR DESCRIPTION
Apologies for missing this in the previous PR (#5).

The PDFium version in `ios/flutter_pdfium.podspec` was not updated when the Android side was bumped.
This PR corrects that and aligns the iOS configuration accordingly.